### PR TITLE
Prototype of frontend expanded

### DIFF
--- a/client/src/components/AddSpeedDial.js
+++ b/client/src/components/AddSpeedDial.js
@@ -67,7 +67,7 @@ class AddSpeedDial extends React.Component {
           direction="down"
         >
           <SpeedDialAction
-            tooltipTitle="Add table"
+            tooltipTitle="Add Person"
             icon={<PersonIcon />}
             onClick={this.handlePlayersOpen}
           />

--- a/client/src/components/AddTableDialog.js
+++ b/client/src/components/AddTableDialog.js
@@ -22,7 +22,7 @@ class AddTableDialog extends React.Component {
   };
 
   handleSelect = table => {
-    this.props.addTable(this.props.tournament, table);
+    this.props.addTable(this.props.tournamentId, table);
   };
 
   handleAdd = () => {
@@ -114,7 +114,7 @@ AddTableDialog.propTypes = {
   onClose: PropTypes.func.isRequired,
   addTable: PropTypes.func.isRequired,
   tables: PropTypes.array.isRequired,
-  tournament: PropTypes.string.isRequired,
+  tournamentId: PropTypes.string.isRequired,
   fetch: PropTypes.func.isRequired,
 };
 

--- a/client/src/components/AddTableDialog.js
+++ b/client/src/components/AddTableDialog.js
@@ -23,7 +23,6 @@ class AddTableDialog extends React.Component {
 
   handleSelect = table => {
     this.props.addTable(this.props.tournament, table);
-    this.props.onClose();
   };
 
   handleAdd = () => {
@@ -53,7 +52,7 @@ class AddTableDialog extends React.Component {
               <ListItem
                 button
                 key={table.name}
-                onClick={() => this.handleSelect(table.name)}
+                onClick={() => this.handleSelect(table.uuid)}
               >
                 <ListItemText primary={table.name} />
               </ListItem>

--- a/client/src/components/AddTableDialog.js
+++ b/client/src/components/AddTableDialog.js
@@ -9,7 +9,14 @@ import { PropTypes } from 'prop-types';
 import Divider from '@material-ui/core/Divider';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import AddIcon from '@material-ui/icons/Add';
+import { Grid, TextField, Button } from '@material-ui/core';
 class AddTableDialog extends React.Component {
+  state = {
+    name: '',
+    rightColor: '',
+    leftColor: '',
+  };
+
   handleClose = () => {
     this.props.onClose();
   };
@@ -26,6 +33,14 @@ class AddTableDialog extends React.Component {
   componentDidMount() {
     this.props.fetch();
   }
+
+  create = () => {
+    this.props.createTable(
+      this.state.name,
+      this.state.rightColor,
+      this.state.leftColor
+    );
+  };
 
   render() {
     const { tables, open } = this.props;
@@ -51,6 +66,45 @@ class AddTableDialog extends React.Component {
               <ListItemText primary="New table" />
             </ListItem>
           </List>
+          <Grid container direction="column">
+            <Grid item>
+              <TextField
+                helperText="Name"
+                value={this.state.name}
+                onChange={event =>
+                  this.setState({
+                    name: event.target.value,
+                  })
+                }
+                lable="Name"
+              />
+            </Grid>
+            <Grid item>
+              <TextField
+                helperText="Right Color"
+                value={this.state.rightColor}
+                onChange={event =>
+                  this.setState({ rightColor: event.target.value })
+                }
+                lable="Right Color"
+              />
+            </Grid>
+            <Grid item>
+              <TextField
+                helperText="Left Color"
+                value={this.state.leftColor}
+                onChange={event =>
+                  this.setState({ leftColor: event.target.value })
+                }
+                lable="Lef Color"
+              />
+            </Grid>
+            <Grid item>
+              <Button variant="outlined" onClick={this.create}>
+                Create
+              </Button>
+            </Grid>
+          </Grid>
         </div>
       </Dialog>
     );

--- a/client/src/components/Games.js
+++ b/client/src/components/Games.js
@@ -59,6 +59,16 @@ function Players(props) {
 }
 
 class Game extends React.Component {
+  registerGame(wereRightWinner) {
+    this.props.registerGame(
+      this.props.data.tournamentId,
+      this.props.data.table.uuid,
+      this.props.data.leftPlayers,
+      this.props.data.rightPlayers,
+      wereRightWinner
+    );
+  }
+
   render() {
     const { classes } = this.props;
     const { data } = this.props;
@@ -70,16 +80,22 @@ class Game extends React.Component {
             className={classes.score}
             color="secondary"
             variant="determinate"
-            value={data.rightScore / (data.rightScore + data.leftScore) * 100}
+            value={(data.rightScore / (data.rightScore + data.leftScore)) * 100}
           />
           <div size="small" className={classes.row}>
-            <Button className={classes.button}>
+            <Button
+              className={classes.button}
+              onClick={() => this.registerGame(true)}
+            >
               {data.table.color.right} wins {data.rightScore} points
             </Button>
           </div>
           <Divider />
           <div size="small" className={classes.row}>
-            <Button className={classes.button}>
+            <Button
+              className={classes.button}
+              onClick={() => this.registerGame(false)}
+            >
               {data.table.color.left} wins {data.leftScore} points
             </Button>
           </div>
@@ -87,7 +103,7 @@ class Game extends React.Component {
             className={classes.score}
             color="secondary"
             variant="determinate"
-            value={data.leftScore / (data.rightScore + data.leftScore) * 100}
+            value={(data.leftScore / (data.rightScore + data.leftScore)) * 100}
           />
           <Players data={data.leftPlayers} classes={classes} />
         </CardContent>
@@ -107,7 +123,12 @@ class Games extends React.Component {
     return (
       <div>
         {data.map(game => (
-          <Game key={game.uuid} classes={classes} data={game} />
+          <Game
+            key={game.uuid}
+            classes={classes}
+            data={game}
+            registerGame={this.props.registerGame}
+          />
         ))}
       </div>
     );

--- a/client/src/components/Players.js
+++ b/client/src/components/Players.js
@@ -41,7 +41,7 @@ class Player extends React.Component {
         <ListItemText primary={data.nickname} secondary={data.realname} />
         <ListItemSecondaryAction>
           <Chip label={data.ranking} className={classes.chip} />
-        </ListItemSecondaryAction>f
+        </ListItemSecondaryAction>
       </ListItem>
     );
   }

--- a/client/src/components/Tables.js
+++ b/client/src/components/Tables.js
@@ -1,0 +1,85 @@
+import Avatar from '@material-ui/core/Avatar';
+import React from 'react';
+import PropTypes from 'prop-types';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import { Divider } from '@material-ui/core';
+
+class Table extends React.Component {
+  constructor(props) {
+    super(props);
+    this.select = this.select.bind(this);
+    this.deselect = this.deselect.bind(this);
+  }
+
+  select() {
+    this.props.select(this.props.tournamentId, this.props.tables.uuid);
+  }
+
+  deselect() {
+    this.props.deselect(this.props.tournamentId, this.props.tables.uuid);
+  }
+
+  render() {
+    const { classes } = this.props;
+    const { table } = this.props;
+    return (
+      <ListItem>
+        <Avatar className={classes.avatar}>{table.name.substring(0, 2)}</Avatar>
+        <ListItemText primary={table.name} secondary="Name" />
+        <ListItemText primary={table.color.right} secondary="Right color" />
+        <ListItemText primary={table.color.left} secondary="Left color" />
+      </ListItem>
+    );
+  }
+}
+
+class Tables extends React.Component {
+  componentDidMount() {
+    this.props.fetch(this.props.tournamentId);
+  }
+
+  render() {
+    const { classes } = this.props;
+    const { tables } = this.props;
+    return (
+      <List className={classes.list}>
+        {tables &&
+          tables.map((p, i) => (
+            <div key={p.uuid}>
+              <Table
+                table={p}
+                tournament={this.props.tournamentId}
+                select={this.props.select}
+                deselect={this.props.deselect}
+                classes={classes}
+              />
+              {i !== tables.length - 1 ? (
+                <li>
+                  <Divider variant="inset" />
+                </li>
+              ) : null}
+            </div>
+          ))}
+      </List>
+    );
+  }
+}
+
+Tables.propTypes = {
+  classes: PropTypes.object.isRequired,
+  tables: PropTypes.array.isRequired,
+  tournamentId: PropTypes.string.isRequired,
+  fetch: PropTypes.func,
+};
+
+Table.propTypes = {
+  classes: PropTypes.object.isRequired,
+  table: PropTypes.object.isRequired,
+  tournament: PropTypes.string.isRequired,
+  deselect: PropTypes.func.isRequired,
+  select: PropTypes.func.isRequired,
+};
+
+export default Tables;

--- a/client/src/components/Tables.js
+++ b/client/src/components/Tables.js
@@ -4,21 +4,16 @@ import PropTypes from 'prop-types';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
-import { Divider } from '@material-ui/core';
+import { Divider, ListItemSecondaryAction, Chip } from '@material-ui/core';
 
 class Table extends React.Component {
   constructor(props) {
     super(props);
-    this.select = this.select.bind(this);
     this.deselect = this.deselect.bind(this);
   }
 
-  select() {
-    this.props.select(this.props.tournamentId, this.props.tables.uuid);
-  }
-
   deselect() {
-    this.props.deselect(this.props.tournamentId, this.props.tables.uuid);
+    this.props.deselect(this.props.tournamentId, this.props.table.uuid);
   }
 
   render() {
@@ -30,6 +25,13 @@ class Table extends React.Component {
         <ListItemText primary={table.name} secondary="Name" />
         <ListItemText primary={table.color.right} secondary="Right color" />
         <ListItemText primary={table.color.left} secondary="Left color" />
+        <ListItemSecondaryAction>
+          <Chip
+            label="Remove"
+            className={classes.chip}
+            onClick={this.deselect}
+          />
+        </ListItemSecondaryAction>
       </ListItem>
     );
   }
@@ -50,8 +52,7 @@ class Tables extends React.Component {
             <div key={p.uuid}>
               <Table
                 table={p}
-                tournament={this.props.tournamentId}
-                select={this.props.select}
+                tournamentId={this.props.tournamentId}
                 deselect={this.props.deselect}
                 classes={classes}
               />
@@ -77,9 +78,8 @@ Tables.propTypes = {
 Table.propTypes = {
   classes: PropTypes.object.isRequired,
   table: PropTypes.object.isRequired,
-  tournament: PropTypes.string.isRequired,
+  tournamentId: PropTypes.string.isRequired,
   deselect: PropTypes.func.isRequired,
-  select: PropTypes.func.isRequired,
 };
 
 export default Tables;

--- a/client/src/components/TournamentPlayers.js
+++ b/client/src/components/TournamentPlayers.js
@@ -48,15 +48,6 @@ class TournamentPlayers extends React.Component {
     const { paper, ...childClasses } = classes;
     return (
       <Paper className={paper} elevation={4}>
-        <Players
-          classes={childClasses}
-          fetch={this.props.fetch}
-          select={this.props.select}
-          deselect={this.props.deselect}
-          data={this.props.data}
-          id={this.props.id}
-        />
-        <Divider />
         <BottomNavigation showLabels>
           <BottomNavigationAction
             onClick={this.handleOpen}
@@ -69,6 +60,15 @@ class TournamentPlayers extends React.Component {
             id={this.props.id}
           />
         </BottomNavigation>
+        <Divider />
+        <Players
+          classes={childClasses}
+          fetch={this.props.fetch}
+          select={this.props.select}
+          deselect={this.props.deselect}
+          data={this.props.data}
+          id={this.props.id}
+        />
       </Paper>
     );
   }

--- a/client/src/components/TournamentTables.js
+++ b/client/src/components/TournamentTables.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import withRoot from '../withRoot';
+import Paper from '@material-ui/core/Paper';
+import Divider from '@material-ui/core/Divider';
+import Tables from './Tables';
+
+const styles = theme => ({
+  paper: {
+    maxWidth: 250,
+    minWidth: 250,
+    margin: 20,
+    display: 'flex',
+    flexFlow: 'column',
+  },
+  avatar: {
+    backgroundColor: theme.palette.secondary.main,
+  },
+  list: {
+    flex: 1,
+  },
+});
+
+class TournamentTables extends React.Component {
+  state = {
+    open: false,
+  };
+
+  componentDidMount() {
+    this.props.fetch(this.props.tournamentId);
+  }
+
+  handleClose = () => {
+    this.setState({ open: false });
+  };
+
+  handleOpen = () => {
+    this.setState({ open: true });
+  };
+
+  render() {
+    const { classes } = this.props;
+    const { paper, ...childClasses } = classes;
+    return (
+      <Paper className={paper} elevation={4}>
+        <Tables
+          classes={childClasses}
+          fetch={this.props.fetch}
+          select={this.props.select}
+          deselect={this.props.deselect}
+          tables={this.props.tables}
+          tournamentId={this.props.tournamentId}
+        />
+        <Divider />
+        {/* <BottomNavigation showLabels>
+          <BottomNavigationAction
+            onClick={this.handleOpen}
+            label="Add"
+            icon={<AddIcon />}
+          />
+          <AddPlayers
+            open={this.state.open}
+            onClose={this.handleClose}
+            id={this.props.id}
+          />
+        </BottomNavigation> */}
+      </Paper>
+    );
+  }
+}
+
+TournamentTables.propTypes = {
+  classes: PropTypes.object.isRequired,
+  fetch: PropTypes.func.isRequired,
+  select: PropTypes.func.isRequired,
+  deselect: PropTypes.func.isRequired,
+  talbes: PropTypes.array.isRequired,
+  tournamentId: PropTypes.string.isRequired,
+};
+
+export default withRoot(withStyles(styles)(TournamentTables));

--- a/client/src/components/TournamentTables.js
+++ b/client/src/components/TournamentTables.js
@@ -5,11 +5,13 @@ import withRoot from '../withRoot';
 import Paper from '@material-ui/core/Paper';
 import Divider from '@material-ui/core/Divider';
 import Tables from './Tables';
+import { BottomNavigation, BottomNavigationAction } from '@material-ui/core';
+import AddTableDialog from '../containers/AddTableDialog';
+import AddIcon from '@material-ui/icons/Add';
 
 const styles = theme => ({
   paper: {
-    maxWidth: 250,
-    minWidth: 250,
+    minWidth: 450,
     margin: 20,
     display: 'flex',
     flexFlow: 'column',
@@ -44,6 +46,19 @@ class TournamentTables extends React.Component {
     const { paper, ...childClasses } = classes;
     return (
       <Paper className={paper} elevation={4}>
+        <BottomNavigation showLabels>
+          <BottomNavigationAction
+            onClick={this.handleOpen}
+            label="Add"
+            icon={<AddIcon />}
+          />
+          <AddTableDialog
+            open={this.state.open}
+            onClose={this.handleClose}
+            tournamentId={this.props.tournamentId}
+          />
+        </BottomNavigation>
+        <Divider />
         <Tables
           classes={childClasses}
           fetch={this.props.fetch}
@@ -52,19 +67,6 @@ class TournamentTables extends React.Component {
           tables={this.props.tables}
           tournamentId={this.props.tournamentId}
         />
-        <Divider />
-        {/* <BottomNavigation showLabels>
-          <BottomNavigationAction
-            onClick={this.handleOpen}
-            label="Add"
-            icon={<AddIcon />}
-          />
-          <AddPlayers
-            open={this.state.open}
-            onClose={this.handleClose}
-            id={this.props.id}
-          />
-        </BottomNavigation> */}
       </Paper>
     );
   }

--- a/client/src/components/Tournaments.js
+++ b/client/src/components/Tournaments.js
@@ -59,6 +59,28 @@ class Tournament extends React.Component {
   }
 }
 
+class NewTournament extends React.Component {
+  create = () => {
+    this.props.addTournament();
+  };
+
+  render() {
+    return (
+      <Card elevation={4}>
+        <CardHeader
+          title="New Tournament"
+          subheader="Fill out the form and press add to create the tournament."
+        />
+        <CardActions>
+          <Button size="small" color="primary" onClick={this.create}>
+            Add
+          </Button>
+        </CardActions>
+      </Card>
+    );
+  }
+}
+
 class Tournaments extends React.Component {
   componentDidMount() {
     this.props.fetch();
@@ -69,6 +91,7 @@ class Tournaments extends React.Component {
     const { data } = this.props;
     return (
       <div className={classes.root}>
+        <NewTournament />
         {Object.values(data).map(tournament => (
           <Tournament
             key={tournament.uuid}

--- a/client/src/components/Tournaments.js
+++ b/client/src/components/Tournaments.js
@@ -10,6 +10,7 @@ import { withStyles } from '@material-ui/core/styles';
 import withRoot from '../withRoot';
 import { Link } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
+import { TextField } from '@material-ui/core';
 
 const styles = theme => ({
   card: {
@@ -60,8 +61,18 @@ class Tournament extends React.Component {
 }
 
 class NewTournament extends React.Component {
+  state = {
+    name: '',
+    score: '50',
+    initial: '1500',
+  };
+
   create = () => {
-    this.props.addTournament();
+    this.props.createTournament(
+      this.state.name,
+      this.state.score,
+      this.state.initial
+    );
   };
 
   render() {
@@ -71,6 +82,28 @@ class NewTournament extends React.Component {
           title="New Tournament"
           subheader="Fill out the form and press add to create the tournament."
         />
+        <CardContent>
+          <TextField
+            helperText="Name"
+            value={this.state.name}
+            onChange={event => this.setState({ name: event.target.value })}
+            lable="Name"
+          />
+          <TextField
+            helperText="Score"
+            value={this.state.score}
+            onChange={event => this.setState({ score: event.target.value })}
+            lable="Score"
+            keyboardType="number-pad"
+          />
+          <TextField
+            helperText="Initial"
+            value={this.state.initial}
+            onChange={event => this.setState({ initial: event.target.value })}
+            lable="Initial"
+            keyboardType="number-pad"
+          />
+        </CardContent>
         <CardActions>
           <Button size="small" color="primary" onClick={this.create}>
             Add
@@ -91,7 +124,7 @@ class Tournaments extends React.Component {
     const { data } = this.props;
     return (
       <div className={classes.root}>
-        <NewTournament />
+        <NewTournament createTournament={this.props.createTournament} />
         {Object.values(data).map(tournament => (
           <Tournament
             key={tournament.uuid}

--- a/client/src/containers/AddTableDialog.js
+++ b/client/src/containers/AddTableDialog.js
@@ -17,6 +17,9 @@ const mapDispatchToProps = dispatch => {
     fetch: () => {
       dispatch(fetchAllTables());
     },
+    createTable: (name, right, left) => {
+      dispatch(createTable(name, right, left));
+    },
   };
 };
 

--- a/client/src/containers/AddTableDialog.js
+++ b/client/src/containers/AddTableDialog.js
@@ -5,14 +5,14 @@ import { fetchAllTables, createTable, activateTable } from './../services';
 const mapStateToProps = (state, props) => {
   return {
     tables: Object.keys(state.tables).map(id => ({ ...state.tables[id] })),
-    tournament: props.tournament,
+    tournamentId: props.tournamentId,
   };
 };
 
 const mapDispatchToProps = dispatch => {
   return {
-    addTable: (tournament, table) => {
-      dispatch(activateTable(tournament, table));
+    addTable: (tournamentId, table) => {
+      dispatch(activateTable(tournamentId, table));
     },
     fetch: () => {
       dispatch(fetchAllTables());

--- a/client/src/containers/AddTableDialog.js
+++ b/client/src/containers/AddTableDialog.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import AddTableDialogComponent from '../components/AddTableDialog';
-import { fetchAllTables, createTable } from './../services';
+import { fetchAllTables, createTable, activateTable } from './../services';
 
 const mapStateToProps = (state, props) => {
   return {
@@ -12,7 +12,7 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = dispatch => {
   return {
     addTable: (tournament, table) => {
-      dispatch(createTable(tournament, table));
+      dispatch(activateTable(tournament, table));
     },
     fetch: () => {
       dispatch(fetchAllTables());

--- a/client/src/containers/AllTournaments.js
+++ b/client/src/containers/AllTournaments.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import Tournaments from '../components/Tournaments';
-import { fetchTournaments } from '../services';
+import { fetchTournaments, createTournament } from '../services';
 import Refresh from '../components/Refresh';
 import { getTournaments } from '../reducers/tournaments';
 
@@ -12,6 +12,9 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => ({
   fetch: () => {
     dispatch(fetchTournaments());
+  },
+  addTournament: (tournament, table) => {
+    dispatch(createTournament(tournament, table));
   },
 });
 

--- a/client/src/containers/AllTournaments.js
+++ b/client/src/containers/AllTournaments.js
@@ -13,8 +13,8 @@ const mapDispatchToProps = dispatch => ({
   fetch: () => {
     dispatch(fetchTournaments());
   },
-  addTournament: (tournament, table) => {
-    dispatch(createTournament(tournament, table));
+  createTournament: (name, score, initial) => {
+    dispatch(createTournament(name, score, initial));
   },
 });
 

--- a/client/src/containers/GamesInTournament.js
+++ b/client/src/containers/GamesInTournament.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { fetchRandomgames } from '../services';
+import { fetchRandomgames, registerGame } from '../services';
 import Games from '../components/Games';
 
 const mapStateToProps = (state, props) => {
@@ -13,6 +13,22 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = dispatch => {
   return {
     fetch: id => dispatch(fetchRandomgames(id)),
+    registerGame: (
+      tournamentId,
+      tableId,
+      leftPLayers,
+      rightPlayers,
+      wereRightWinner
+    ) =>
+      dispatch(
+        registerGame(
+          tournamentId,
+          tableId,
+          leftPLayers,
+          rightPlayers,
+          wereRightWinner
+        )
+      ),
   };
 };
 

--- a/client/src/containers/TournamentTables.js
+++ b/client/src/containers/TournamentTables.js
@@ -1,0 +1,33 @@
+import { connect } from 'react-redux';
+import TournamentTablesComponent from '../components/TournamentTables';
+import {
+  fetchTournamentTables,
+  activateTable,
+  deactivateTable,
+} from '../services';
+import { getTables } from '../reducers/tournaments';
+
+const mapStateToProps = (state, props) => {
+  return {
+    tournamentId: props.id,
+    tables: getTables(state),
+  };
+};
+const mapDispatchToProps = dispatch => {
+  return {
+    fetch: tournamentId => {
+      dispatch(fetchTournamentTables(tournamentId));
+    },
+    select: (tournamentId, tableId) =>
+      dispatch(activateTable(tournamentId, tableId)),
+    deselect: (tournamentId, tableId) =>
+      dispatch(deactivateTable(tournamentId, tableId)),
+  };
+};
+
+const TournamentTables = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(TournamentTablesComponent);
+
+export default TournamentTables;

--- a/client/src/pages/Tournament.js
+++ b/client/src/pages/Tournament.js
@@ -9,6 +9,7 @@ import Start from '../components/Start';
 import AddSpeedDial from '../components/AddSpeedDial';
 import GamesInTournament from '../containers/GamesInTournament';
 import RandomGames from '../containers/RandomGames';
+import TournamentTables from '../containers/TournamentTables';
 
 const styles = theme => ({
   root: {
@@ -40,6 +41,7 @@ class Tournament extends React.Component {
         </Menu>
         <div className={classes.content}>
           <TournamentPlayers id={this.props.match.params.id} />
+          <TournamentTables id={this.props.match.params.id} />
           <GamesInTournament id={this.props.match.params.id} />
         </div>
       </div>

--- a/client/src/reducers/games.js
+++ b/client/src/reducers/games.js
@@ -1,0 +1,23 @@
+export const types = {
+  REGISTERED_GAME: 'GAMES/REGISTERED_GAME',
+};
+
+export const actions = {
+  registerGame: json => ({
+    type: types.REGISTERED_GAME,
+    json,
+    receivedAt: Date.now(),
+  }),
+};
+
+export default (state = {}, action) => {
+  switch (action.type) {
+    case types.REGISTERED_GAME:
+      return {
+        ...state,
+        [action.json.uuid]: action.json,
+      };
+    default:
+      return state;
+  }
+};

--- a/client/src/reducers/tables.js
+++ b/client/src/reducers/tables.js
@@ -13,8 +13,9 @@ export const actions = {
   requestAllTables: () => ({
     type: types.REQUEST_ALL_TABLES,
   }),
-  addTable: (name, right, left) => ({
+  addTable: (uuid, name, right, left) => ({
     type: types.ADD_TABLE,
+    uuid,
     name,
     color: { right: right, left: left },
   }),
@@ -29,7 +30,10 @@ export default (state = {}, action) => {
           [t.uuid]: {
             uuid: t.uuid,
             name: t.name,
-            color: t.color,
+            color: {
+              right: t.color.right,
+              left: t.color.left,
+            },
           },
         }),
         {}
@@ -41,9 +45,13 @@ export default (state = {}, action) => {
     case types.ADD_TABLE:
       return {
         ...state,
-        [action.name]: {
+        [action.uuid]: {
+          uuid: action.uuid,
           name: action.name,
-          color: action.color,
+          color: {
+            right: action.color.right,
+            left: action.color.left,
+          },
         },
       };
     default:

--- a/client/src/reducers/tournaments.js
+++ b/client/src/reducers/tournaments.js
@@ -11,7 +11,7 @@ export const types = {
 export const actions = {
   requestTournaments: () => ({ type: types.REQUEST_TOURNAMETS }),
   receiveTournaments: tournaments => ({
-    type: types.CREATE_TOURNAMET,
+    type: types.RECEIVE_TOURNAMETS,
     tournaments,
     receivedAt: Date.now(),
   }),

--- a/client/src/reducers/tournaments.js
+++ b/client/src/reducers/tournaments.js
@@ -1,21 +1,32 @@
 export const types = {
   REQUEST_TOURNAMETS: 'TOURNAMETS/REQUEST_TOURNAMETS',
   RECEIVE_TOURNAMETS: 'TOURNAMETS/RECEIVE_TOURNAMETS',
+  CREATE_TOURNAMET: 'TOURNAMETS/CREATE_TOURNAMET',
   REQUEST_TOURNAMET_PLAYERS: 'TOURNAMETS/REQUEST_TOURNAMET_PLAYERS',
   RECEIVE_TOURNAMET_PLAYERS: 'TOURNAMETS/RECEIVE_TOURNAMET_PLAYERS',
+  RECEIVE_TOURNAMET: 'TOURNAMETS/RECEIVE_TOURNAMET',
   ACTIVATE_TOURNAMET_PLAYER: 'TOURNAMETS/ACTIVATE_TOURNAMET_PLAYER',
   DEACTIVATE_TOURNAMET_PLAYER: 'TOURNAMETS/DEACTIVATE_TOURNAMET_PLAYER',
 };
 export const actions = {
   requestTournaments: () => ({ type: types.REQUEST_TOURNAMETS }),
   receiveTournaments: tournaments => ({
-    type: types.RECEIVE_TOURNAMETS,
+    type: types.CREATE_TOURNAMET,
     tournaments,
+    receivedAt: Date.now(),
+  }),
+  createTournament: () => ({
+    type: types.CREATE_TOURNAMET,
     receivedAt: Date.now(),
   }),
   requestTournamentPlayers: id => ({
     type: types.REQUEST_TOURNAMET_PLAYERS,
     id: id,
+  }),
+  receiveTournament: (id) => ({
+    type: types.RECEIVE_TOURNAMET,
+    id,
+    receivedAt: Date.now(),
   }),
   receiveTournamentPlayers: (id, players) => ({
     type: types.RECEIVE_TOURNAMET_PLAYERS,

--- a/client/src/reducers/tournaments.js
+++ b/client/src/reducers/tournaments.js
@@ -23,7 +23,7 @@ export const actions = {
     type: types.REQUEST_TOURNAMET_PLAYERS,
     id: id,
   }),
-  receiveTournament: (id) => ({
+  receiveTournament: id => ({
     type: types.RECEIVE_TOURNAMET,
     id,
     receivedAt: Date.now(),
@@ -44,6 +44,16 @@ export const actions = {
     type: types.DEACTIVATE_TOURNAMET_PLAYER,
     tournamentId,
     nickname,
+  }),
+  activateTournamentTable: (tournamentId, tableId) => ({
+    type: types.ACTIVATE_TOURNAMET_PLAYER,
+    tournamentId,
+    tableId,
+  }),
+  deactivateTournamentTable: (tournamentId, tableId) => ({
+    type: types.DEACTIVATE_TOURNAMET_PLAYER,
+    tournamentId,
+    tableId,
   }),
 };
 

--- a/client/src/reducers/tournaments.js
+++ b/client/src/reducers/tournaments.js
@@ -9,6 +9,8 @@ export const types = {
   RECEIVE_TOURNAMET: 'TOURNAMETS/RECEIVE_TOURNAMET',
   ACTIVATE_TOURNAMET_PLAYER: 'TOURNAMETS/ACTIVATE_TOURNAMET_PLAYER',
   DEACTIVATE_TOURNAMET_PLAYER: 'TOURNAMETS/DEACTIVATE_TOURNAMET_PLAYER',
+  ACTIVATE_TOURNAMET_TABLE: 'TOURNAMETS/ACTIVATE_TOURNAMET_TABLE',
+  DEACTIVATE_TOURNAMET_TABLE: 'TOURNAMETS/DEACTIVATE_TOURNAMET_TABLE',
 };
 export const actions = {
   requestTournaments: () => ({ type: types.REQUEST_TOURNAMETS }),
@@ -58,12 +60,12 @@ export const actions = {
     nickname,
   }),
   activateTournamentTable: (tournamentId, tableId) => ({
-    type: types.ACTIVATE_TOURNAMET_PLAYER,
+    type: types.ACTIVATE_TOURNAMET_TABLE,
     tournamentId,
     tableId,
   }),
   deactivateTournamentTable: (tournamentId, tableId) => ({
-    type: types.DEACTIVATE_TOURNAMET_PLAYER,
+    type: types.DEACTIVATE_TOURNAMET_TABLE,
     tournamentId,
     tableId,
   }),

--- a/client/src/reducers/tournaments.js
+++ b/client/src/reducers/tournaments.js
@@ -3,7 +3,9 @@ export const types = {
   RECEIVE_TOURNAMETS: 'TOURNAMETS/RECEIVE_TOURNAMETS',
   CREATE_TOURNAMET: 'TOURNAMETS/CREATE_TOURNAMET',
   REQUEST_TOURNAMET_PLAYERS: 'TOURNAMETS/REQUEST_TOURNAMET_PLAYERS',
+  REQUEST_TOURNAMET_TABLES: 'TOURNAMETS/REQUEST_TOURNAMET_TABLES',
   RECEIVE_TOURNAMET_PLAYERS: 'TOURNAMETS/RECEIVE_TOURNAMET_PLAYERS',
+  RECEIVE_TOURNAMET_TABLES: 'TOURNAMETS/RECEIVE_TOURNAMET_TABLES',
   RECEIVE_TOURNAMET: 'TOURNAMETS/RECEIVE_TOURNAMET',
   ACTIVATE_TOURNAMET_PLAYER: 'TOURNAMETS/ACTIVATE_TOURNAMET_PLAYER',
   DEACTIVATE_TOURNAMET_PLAYER: 'TOURNAMETS/DEACTIVATE_TOURNAMET_PLAYER',
@@ -23,6 +25,10 @@ export const actions = {
     type: types.REQUEST_TOURNAMET_PLAYERS,
     id: id,
   }),
+  requestTournamentTables: id => ({
+    type: types.REQUEST_TOURNAMET_TABLES,
+    id: id,
+  }),
   receiveTournament: id => ({
     type: types.RECEIVE_TOURNAMET,
     id,
@@ -32,6 +38,12 @@ export const actions = {
     type: types.RECEIVE_TOURNAMET_PLAYERS,
     id,
     players,
+    receivedAt: Date.now(),
+  }),
+  receiveTournamentTables: (id, tables) => ({
+    type: types.RECEIVE_TOURNAMET_TABLES,
+    id,
+    tables,
     receivedAt: Date.now(),
   }),
   activateTournamentPlayer: (tournamentId, nickname, ranking) => ({
@@ -67,6 +79,24 @@ export default (state = {}, action) => {
         }),
         {}
       );
+    case types.RECEIVE_TOURNAMET_TABLES:
+      return {
+        ...state,
+        tables: action.tables.reduce(
+          (a, t) => [
+            ...a,
+            {
+              uuid: t.table.uuid,
+              name: t.table.name,
+              color: {
+                right: t.table.color.right,
+                left: t.table.color.left,
+              },
+            },
+          ],
+          []
+        ),
+      };
     default:
       return state;
   }
@@ -74,4 +104,8 @@ export default (state = {}, action) => {
 
 export function getTournaments(state) {
   return state.tournaments;
+}
+
+export function getTables(state) {
+  return state.tournaments.tables;
 }

--- a/client/src/reducers/tournaments.js
+++ b/client/src/reducers/tournaments.js
@@ -15,7 +15,7 @@ export const actions = {
     tournaments,
     receivedAt: Date.now(),
   }),
-  createTournament: () => ({
+  requestCreateTournament: () => ({
     type: types.CREATE_TOURNAMET,
     receivedAt: Date.now(),
   }),

--- a/client/src/services/games.js
+++ b/client/src/services/games.js
@@ -1,4 +1,5 @@
 import { actions } from '../reducers/random';
+import { actions as gameActions } from '../reducers/games';
 import { handleErrors, transformDateFormat } from './util';
 
 export function fetchRandomgames(id) {
@@ -9,6 +10,39 @@ export function fetchRandomgames(id) {
       .then(json => json.map(transformDateFormat))
       .then(json => {
         dispatch(actions.receiveRandomGames(id, json));
+      });
+  };
+}
+
+export function registerGame(
+  tournamentId,
+  tableId,
+  leftPLayers,
+  rightPlayers,
+  wereRightWinner
+) {
+  return function(dispatch) {
+    return fetch(
+      `http://localhost:8080/tournaments/${tournamentId}/tables/${tableId}/games`,
+      {
+        method: 'POST',
+        redirect: 'follow',
+        headers: new Headers({
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({
+          leftPLayers,
+          rightPlayers,
+          winner: wereRightWinner ? 'RIGHT' : 'LEFT',
+        }),
+      }
+    )
+      .then(handleErrors)
+      .then(response => response.json())
+      .then(json => transformDateFormat(json))
+      .then(json => {
+        dispatch(gameActions.registerGame(json));
       });
   };
 }

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -1,4 +1,4 @@
-import { fetchRandomgames } from './games';
+import { fetchRandomgames, registerGame } from './games';
 import { fetchAllPlayers, createPlayer } from './players';
 import { fetchAllTables, createTable } from './tables';
 import {
@@ -26,4 +26,5 @@ export {
   activateTable,
   deactivateTable,
   fetchTournamentTables,
+  registerGame,
 };

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -9,6 +9,7 @@ import {
   createTournament,
   activateTable,
   deactivateTable,
+  fetchTournamentTables,
 } from './tournaments';
 
 export {
@@ -24,4 +25,5 @@ export {
   createTournament,
   activateTable,
   deactivateTable,
+  fetchTournamentTables,
 };

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -6,6 +6,7 @@ import {
   deactivatePlayer,
   fetchTournaments,
   fetchTournamentPlayers,
+  createTournement,
 } from './tournaments';
 
 export {
@@ -18,4 +19,5 @@ export {
   fetchTournamentPlayers,
   fetchAllTables,
   createTable,
+  createTournement,
 };

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -6,7 +6,7 @@ import {
   deactivatePlayer,
   fetchTournaments,
   fetchTournamentPlayers,
-  createTournement,
+  createTournament,
 } from './tournaments';
 
 export {
@@ -19,5 +19,5 @@ export {
   fetchTournamentPlayers,
   fetchAllTables,
   createTable,
-  createTournement,
+  createTournament,
 };

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -7,6 +7,8 @@ import {
   fetchTournaments,
   fetchTournamentPlayers,
   createTournament,
+  activateTable,
+  deactivateTable,
 } from './tournaments';
 
 export {
@@ -20,4 +22,6 @@ export {
   fetchAllTables,
   createTable,
   createTournament,
+  activateTable,
+  deactivateTable,
 };

--- a/client/src/services/tables.js
+++ b/client/src/services/tables.js
@@ -29,6 +29,10 @@ export function createTable(name, right, left) {
       }),
     })
       .then(handleErrors)
-      .then(response => dispatch(actions.addTable(name, right, left)));
+      .then(response => response.json())
+      .then(json => transformDateFormat(json))
+      .then(response =>
+        dispatch(actions.addTable(response.uuid, name, right, left))
+      );
   };
 }

--- a/client/src/services/tournaments.js
+++ b/client/src/services/tournaments.js
@@ -26,6 +26,18 @@ export function fetchTournamentPlayers(id) {
   };
 }
 
+export function fetchTournamentTables(id) {
+  return function(dispatch) {
+    dispatch(actions.requestTournamentTables(id));
+    return fetch(`http://localhost:8080/tournaments/${id}/tables`)
+      .then(handleErrors)
+      .then(response => response.json())
+      .then(json => {
+        dispatch(actions.receiveTournamentTables(id, json));
+      });
+  };
+}
+
 export function createTournament(name, score, initial) {
   return function(dispatch) {
     dispatch(actions.requestCreateTournament());

--- a/client/src/services/tournaments.js
+++ b/client/src/services/tournaments.js
@@ -61,7 +61,6 @@ export function createTournament(name, score, initial) {
 
 export function activatePlayer(tournamentId, nickname, ranking) {
   return function(dispatch) {
-    dispatch(actions.requestTournaments());
     return fetch(`http://localhost:8080/tournaments/${tournamentId}/players`, {
       method: 'POST',
       redirect: 'follow',
@@ -85,7 +84,6 @@ export function activatePlayer(tournamentId, nickname, ranking) {
 
 export function deactivatePlayer(tournamentId, playerId) {
   return function(dispatch) {
-    dispatch(actions.requestTournaments());
     return fetch(
       `http://localhost:8080/tournaments/${tournamentId}/players/${playerId}`,
       {
@@ -101,7 +99,6 @@ export function deactivatePlayer(tournamentId, playerId) {
 
 export function activateTable(tournamentId, tableId) {
   return function(dispatch) {
-    dispatch(actions.requestTournaments());
     return fetch(`http://localhost:8080/tournaments/${tournamentId}/tables`, {
       method: 'POST',
       redirect: 'follow',
@@ -122,7 +119,6 @@ export function activateTable(tournamentId, tableId) {
 
 export function deactivateTable(tournamentId, tableId) {
   return function(dispatch) {
-    dispatch(actions.requestTournaments());
     return fetch(
       `http://localhost:8080/tournaments/${tournamentId}/tables/${tableId}`,
       {

--- a/client/src/services/tournaments.js
+++ b/client/src/services/tournaments.js
@@ -26,6 +26,27 @@ export function fetchTournamentPlayers(id) {
   };
 }
 
+export function createTournament(name, score, initial) {
+  return function(dispatch) {
+    dispatch(actions.requestCreateTournament());
+    return fetch(`http://localhost:8080/tournaments/`, {
+      method: 'POST',
+      redirect: 'follow',
+      headers: new Headers({
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({
+        name,
+        score: parseInt(score),
+        initial: parseInt(initial),
+      }),
+    })
+      .then(handleErrors)
+      .then(response => fetchTournaments());
+  };
+}
+
 export function activatePlayer(tournamentId, nickname, ranking) {
   return function(dispatch) {
     dispatch(actions.requestTournaments());

--- a/client/src/services/tournaments.js
+++ b/client/src/services/tournaments.js
@@ -86,3 +86,40 @@ export function deactivatePlayer(tournamentId, playerId) {
       );
   };
 }
+
+export function activateTable(tournamentId, tableId) {
+  return function(dispatch) {
+    dispatch(actions.requestTournaments());
+    return fetch(`http://localhost:8080/tournaments/${tournamentId}/tables`, {
+      method: 'POST',
+      redirect: 'follow',
+      headers: new Headers({
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({
+        uuid: tableId,
+      }),
+    })
+      .then(handleErrors)
+      .then(response =>
+        dispatch(actions.activateTournamentTable(tournamentId, tableId))
+      );
+  };
+}
+
+export function deactivateTable(tournamentId, tableId) {
+  return function(dispatch) {
+    dispatch(actions.requestTournaments());
+    return fetch(
+      `http://localhost:8080/tournaments/${tournamentId}/tables/${tableId}`,
+      {
+        method: 'DELETE',
+      }
+    )
+      .then(handleErrors)
+      .then(response =>
+        dispatch(actions.deactivateTournamentTable(tournamentId, tableId))
+      );
+  };
+}


### PR DESCRIPTION
So now we can create
Tournament
Players
tables
random games. 

When the backend is up to date then we can: 
Remove tables. 
Register a win on a game. 

What is missing: 
List of played games in tournament
Moving clock into main tournament view, so you can register players while game is in progress
Players statisticks (Likely something the backend need to implement first) 
Genereal UI and bug fixes, so it is not as prototype-ish

What could be nice: 
Tournament generation: Genereate a hole tournament in one go. 